### PR TITLE
Add unit dependencies for PostgreSQL-backed quadlets

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,13 @@ When you select Guacamole, QuadStack also adds a one-shot `guacamole-db-init.ser
 3. Append its raw URL (or local path) to `container-manifest.txt`.
 4. Run QuadStack and select it.
 
+### Reload systemd after Quadlet updates
+
+Whenever you edit existing Quadlet files, reload systemd so the new dependencies are applied.
+
+- System services: `sudo systemctl daemon-reload`
+- Rootless services: `systemctl --user daemon-reload`
+
 ---
 
 ## Troubleshooting

--- a/quadlets/guacamole.container
+++ b/quadlets/guacamole.container
@@ -1,3 +1,9 @@
+[Unit]
+Description=Guacamole container
+Requires=container-postgresql.service container-guacd.service
+After=container-postgresql.service container-guacd.service network-online.target
+Wants=network-online.target
+
 [Container]
 ContainerName=guacamole
 Image=docker.io/guacamole/guacamole:1.6.0

--- a/quadlets/keycloak.container
+++ b/quadlets/keycloak.container
@@ -1,3 +1,9 @@
+[Unit]
+Description=Keycloak container
+Requires=container-postgresql.service
+After=container-postgresql.service network-online.target
+Wants=network-online.target
+
 [Container]
 ContainerName=keycloak
 Image=quay.io/keycloak/keycloak:26.3.5

--- a/quadlets/pwpush.container
+++ b/quadlets/pwpush.container
@@ -1,3 +1,9 @@
+[Unit]
+Description=Password Pusher container
+Requires=container-postgresql.service
+After=container-postgresql.service network-online.target
+Wants=network-online.target
+
 [Container]
 ContainerName=pwpush
 Image=docker.io/pglombardo/pwpush:latest


### PR DESCRIPTION
## Summary
- add Unit sections to the Guacamole, Keycloak, and Password Pusher quadlets so they order after PostgreSQL and network-online
- document the need to reload systemd after editing quadlets to apply dependency changes

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68dc402a793883269ad0d3fd6414be1e