### PR TITLE
Add Rancher quadlet for Kubernetes management

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.worktrees/

--- a/container-manifest.txt
+++ b/container-manifest.txt
@@ -11,3 +11,4 @@ https://raw.githubusercontent.com/cragr/quadstack/refs/heads/main/quadlets/n8n.c
 https://raw.githubusercontent.com/cragr/quadstack/refs/heads/main/quadlets/pihole.container
 https://raw.githubusercontent.com/cragr/quadstack/refs/heads/main/quadlets/minecraft-bedrock.container
 https://raw.githubusercontent.com/cragr/quadstack/refs/heads/main/quadlets/minecraft-java.container
+https://raw.githubusercontent.com/cragr/quadstack/refs/heads/main/quadlets/rancher.container

--- a/docs/plans/2026-02-04-rancher-quadlet-design.md
+++ b/docs/plans/2026-02-04-rancher-quadlet-design.md
@@ -1,0 +1,85 @@
+# Rancher Quadlet Design
+
+## Overview
+
+Add Rancher to QuadStack for managing external Kubernetes clusters (RKE2, K3s, etc.).
+
+## Configuration
+
+**Image:** `docker.io/rancher/rancher:stable`
+
+**Backend:** External PostgreSQL via QuadStack's `# RequiresPostgres:` mechanism
+
+**Network:** Behind NPM Plus reverse proxy (HTTP only internally, TLS at proxy)
+
+**Tokens:** Standard only (`{{INSTALL_DIR}}`, `{{HOST_PORT}}`)
+
+## Quadlet Configuration
+
+**File:** `quadlets/rancher.container`
+
+```ini
+# Name: Rancher
+# Description: Kubernetes management platform for managing external clusters
+# DefaultPort: 8080
+# RequiresPostgres: rancher
+# Requires: Network
+
+[Container]
+Image=docker.io/rancher/rancher:stable
+ContainerName=rancher
+Network=appnet
+PublishPort={{HOST_PORT}}:80
+Environment=CATTLE_DB_CATTLE_POSTGRES_HOST=postgres
+Environment=CATTLE_DB_CATTLE_POSTGRES_PORT=5432
+Environment=CATTLE_DB_CATTLE_POSTGRES_NAME=rancher
+Environment=CATTLE_DB_CATTLE_POSTGRES_USER=rancher
+Environment=CATTLE_DB_CATTLE_POSTGRES_PASSWORD={{POSTGRES_RANCHER_PASSWORD}}
+Environment=AUDIT_LEVEL=1
+Volume={{INSTALL_DIR}}/rancher:/var/lib/rancher:Z,U
+
+[Service]
+Restart=always
+
+[Install]
+WantedBy=default.target
+```
+
+## Manifest Entry
+
+**File:** `manifest.txt`
+
+```
+rancher|Rancher|Kubernetes management platform|8080
+```
+
+## Installation Behavior
+
+1. QuadStack checks for `# RequiresPostgres: rancher` metadata
+2. If PostgreSQL quadlet isn't already selected, it's auto-added
+3. Installer prompts for `HOST_PORT` (default: 8080)
+4. PostgreSQL password for the `rancher` database is auto-generated and injected
+5. Creates `{{INSTALL_DIR}}/rancher/` directory with proper SELinux context
+6. Installs quadlet to `/etc/containers/systemd/rancher.container`
+7. Runs `systemctl daemon-reload` and starts the service
+
+## Post-Install Note
+
+```
+Rancher is starting up (this takes 1-2 minutes on first run).
+Access via your reverse proxy or http://<host>:8080
+Default admin user: admin
+Retrieve bootstrap password: podman logs rancher 2>&1 | grep "Bootstrap Password"
+```
+
+## Dependencies
+
+- **Required:** PostgreSQL quadlet (auto-selected via `# RequiresPostgres:`)
+- **Required:** Network quadlet (for `appnet`)
+- **Optional:** NPM Plus for TLS termination (user configures separately)
+
+## Files to Create/Modify
+
+1. `quadlets/rancher.container` - new file
+2. `manifest.txt` - add entry
+3. `README.md` - add to services list

--- a/docs/plans/2026-02-04-rancher-quadlet-implementation.md
+++ b/docs/plans/2026-02-04-rancher-quadlet-implementation.md
@@ -1,0 +1,132 @@
+# Rancher Quadlet Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add Rancher Kubernetes management platform to QuadStack with PostgreSQL backend.
+
+**Architecture:** Rancher runs on appnet, connects to PostgreSQL for persistent storage, and is accessed via NPM Plus reverse proxy. No direct host port exposure needed.
+
+**Tech Stack:** Podman Quadlet, PostgreSQL, systemd
+
+---
+
+## Task 1: Create Rancher Quadlet File
+
+**Files:**
+- Create: `quadlets/rancher.container`
+
+**Step 1: Create the quadlet file**
+
+Create `quadlets/rancher.container` with this exact content:
+
+```ini
+[Unit]
+Description=Rancher container
+Requires=postgresql.service
+After=postgresql.service network-online.target
+Wants=network-online.target
+
+[Container]
+ContainerName=rancher
+Image=docker.io/rancher/rancher:stable
+Network=appnet
+
+# Persist Rancher data
+Volume={{INSTALL_DIR}}/rancher:/var/lib/rancher:Z,U
+
+# RequiresPostgres:
+# Database (PostgreSQL)
+Environment=CATTLE_DB_CATTLE_POSTGRES_HOST=postgresql
+Environment=CATTLE_DB_CATTLE_POSTGRES_PORT=5432
+Environment=CATTLE_DB_CATTLE_POSTGRES_NAME={{RANCHER_DB_NAME}}
+Environment=CATTLE_DB_CATTLE_POSTGRES_USER={{RANCHER_DB_USERNAME}}
+Environment=CATTLE_DB_CATTLE_POSTGRES_PASSWORD={{RANCHER_DB_PASSWORD}}
+
+# Audit logging (level 1 = basic)
+Environment=AUDIT_LEVEL=1
+
+[Service]
+Restart=always
+TimeoutStartSec=900
+
+[Install]
+WantedBy=default.target
+```
+
+**Step 2: Verify file syntax**
+
+Run: `cat quadlets/rancher.container`
+Expected: File displays without errors, contains all sections
+
+**Step 3: Commit**
+
+```bash
+git add quadlets/rancher.container
+git commit -m "feat: add rancher quadlet for Kubernetes management"
+```
+
+---
+
+## Task 2: Add Rancher to Container Manifest
+
+**Files:**
+- Modify: `container-manifest.txt` (add 1 line at end)
+
+**Step 1: Add manifest entry**
+
+Append this line to `container-manifest.txt`:
+
+```
+https://raw.githubusercontent.com/cragr/quadstack/refs/heads/main/quadlets/rancher.container
+```
+
+**Step 2: Verify manifest**
+
+Run: `tail -3 container-manifest.txt`
+Expected: Shows rancher.container as last entry
+
+**Step 3: Commit**
+
+```bash
+git add container-manifest.txt
+git commit -m "feat: add rancher to container manifest"
+```
+
+---
+
+## Task 3: Update README with Rancher
+
+**Files:**
+- Modify: `README.md` (services section - not explicitly listed, but implied in docs)
+
+**Step 1: No explicit service list in README**
+
+The README doesn't have a services list to update. Skip this task.
+
+**Step 2: Commit (skip if no changes)**
+
+No commit needed.
+
+---
+
+## Task 4: Final Verification
+
+**Step 1: Verify all files are present**
+
+Run: `ls -la quadlets/rancher.container container-manifest.txt`
+Expected: Both files exist
+
+**Step 2: Verify manifest entry format**
+
+Run: `grep rancher container-manifest.txt`
+Expected: Shows the rancher.container URL
+
+**Step 3: Verify quadlet has required metadata**
+
+Run: `grep -E "(RequiresPostgres|CATTLE_DB)" quadlets/rancher.container`
+Expected: Shows PostgreSQL requirement comment and all CATTLE_DB environment variables
+
+**Step 4: View git log**
+
+Run: `git log --oneline -5`
+Expected: Shows recent commits for rancher quadlet and manifest update

--- a/quadlets/rancher.container
+++ b/quadlets/rancher.container
@@ -1,0 +1,31 @@
+[Unit]
+Description=Rancher container
+Requires=postgresql.service
+After=postgresql.service network-online.target
+Wants=network-online.target
+
+[Container]
+ContainerName=rancher
+Image=docker.io/rancher/rancher:stable
+Network=appnet
+
+# Persist Rancher data
+Volume={{INSTALL_DIR}}/rancher:/var/lib/rancher:Z,U
+
+# RequiresPostgres:
+# Database (PostgreSQL)
+Environment=CATTLE_DB_CATTLE_POSTGRES_HOST=postgresql
+Environment=CATTLE_DB_CATTLE_POSTGRES_PORT=5432
+Environment=CATTLE_DB_CATTLE_POSTGRES_NAME={{RANCHER_DB_NAME}}
+Environment=CATTLE_DB_CATTLE_POSTGRES_USER={{RANCHER_DB_USERNAME}}
+Environment=CATTLE_DB_CATTLE_POSTGRES_PASSWORD={{RANCHER_DB_PASSWORD}}
+
+# Audit logging (level 1 = basic)
+Environment=AUDIT_LEVEL=1
+
+[Service]
+Restart=always
+TimeoutStartSec=900
+
+[Install]
+WantedBy=default.target


### PR DESCRIPTION
## Summary
- Add `quadlets/rancher.container` for Rancher Kubernetes management platform
- Configure PostgreSQL backend via `# RequiresPostgres:` metadata
- Add rancher to container manifest

## Test Plan
- [ ] Deploy with QuadStack and verify Rancher starts
- [ ] Verify PostgreSQL database is provisioned
- [ ] Access Rancher via NPM Plus reverse proxy

🤖 Generated with [Claude Code](https://claude.ai/code)